### PR TITLE
DT-2968: ⬆️ Upgrade hmpps-gradle-springboot plugin to 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.3.16"
-  kotlin("plugin.spring") version "1.5.30"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.0.0"
+  kotlin("plugin.spring") version "1.6.0"
 }
 
 configurations {
@@ -9,7 +9,6 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
 }
 
 tasks {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditpocapi/integration/health/InfoTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsauditpocapi/integration/health/InfoTest.kt
@@ -16,7 +16,7 @@ class InfoTest : IntegrationTestBase() {
       .expectStatus()
       .isOk
       .expectBody()
-      .jsonPath("app.name").isEqualTo("Hmpps Audit Poc Api")
+      .jsonPath("build.name").isEqualTo("hmpps-audit-poc-api")
   }
 
   @Test


### PR DESCRIPTION
includes springboot 2.6.1 and kotlin 1.6